### PR TITLE
Fix NameError: remove undefined show_instructions_expander()

### DIFF
--- a/website-migration/streamlit-source/website-migration.py
+++ b/website-migration/streamlit-source/website-migration.py
@@ -61,8 +61,6 @@ with st.expander("How to use this tool"):
         unsafe_allow_html=True
     )
 
-    show_instructions_expander()
-
 
 def create_file_uploader_widget(column, file_types):
     """


### PR DESCRIPTION
## Summary
- Removes the call to `show_instructions_expander()` on line 64 which causes a `NameError` on app startup
- The function was replaced by an inline `st.expander("How to use this tool")` block but the old call was never removed

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)