### PR TITLE
Fix broken Open in Colab badge URL

### DIFF
--- a/website-migration/google-colab/Automatic_Website_Migration_V5_by_LeeFoot_07_12_23.ipynb
+++ b/website-migration/google-colab/Automatic_Website_Migration_V5_by_LeeFoot_07_12_23.ipynb
@@ -498,7 +498,7 @@
     "colab_type": "text"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/portfolio/website-migration/google-colab/Automatic_Website_Migration_V5_by_LeeFoot_07_12_23.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/website-migration/google-colab/Automatic_Website_Migration_V5_by_LeeFoot_07_12_23.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {
@@ -534,7 +534,7 @@
       "Requirement already satisfied: seaborn>=0.11.0 in /usr/local/lib/python3.10/dist-packages (from polyfuzz==0.4.2) (0.12.2)\n",
       "Collecting rapidfuzz>=0.13.1 (from polyfuzz==0.4.2)\n",
       "  Downloading rapidfuzz-3.5.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.3 MB)\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m3.3/3.3 MB\u001b[0m \u001b[31m15.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u001b[0m \u001b[32m3.3/3.3 MB\u001b[0m \u001b[31m15.9 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25hRequirement already satisfied: scikit-learn>=0.22.2.post1 in /usr/local/lib/python3.10/dist-packages (from polyfuzz==0.4.2) (1.2.2)\n",
       "Requirement already satisfied: contourpy>=1.0.1 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.2.2->polyfuzz==0.4.2) (1.2.0)\n",
       "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.10/dist-packages (from matplotlib>=3.2.2->polyfuzz==0.4.2) (0.12.1)\n",
@@ -552,7 +552,7 @@
       "Requirement already satisfied: tqdm==4.66.1 in /usr/local/lib/python3.10/dist-packages (4.66.1)\n",
       "Collecting plotly==5.18.0\n",
       "  Downloading plotly-5.18.0-py3-none-any.whl (15.6 MB)\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m15.6/15.6 MB\u001b[0m \u001b[31m44.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[2K     \u001b[90m\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u2501\u001b[0m \u001b[32m15.6/15.6 MB\u001b[0m \u001b[31m44.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
       "\u001b[?25hRequirement already satisfied: tenacity>=6.2.0 in /usr/local/lib/python3.10/dist-packages (from plotly==5.18.0) (8.2.3)\n",
       "Requirement already satisfied: packaging in /usr/local/lib/python3.10/dist-packages (from plotly==5.18.0) (23.2)\n",
       "Installing collected packages: plotly\n",
@@ -1183,7 +1183,7 @@
      "output_type": "display_data",
      "data": {
       "text/plain": [
-       "Dropdown(description='Column 1:', index=1, options=('Optional', 'Address', 'Redirect URL', 'Status Code', 'Sta…"
+       "Dropdown(description='Column 1:', index=1, options=('Optional', 'Address', 'Redirect URL', 'Status Code', 'Sta\u2026"
       ],
       "application/vnd.jupyter.widget-view+json": {
        "version_major": 2,
@@ -1197,7 +1197,7 @@
      "output_type": "display_data",
      "data": {
       "text/plain": [
-       "Dropdown(description='Column 2:', index=19, options=('Optional', 'Address', 'Redirect URL', 'Status Code', 'St…"
+       "Dropdown(description='Column 2:', index=19, options=('Optional', 'Address', 'Redirect URL', 'Status Code', 'St\u2026"
       ],
       "application/vnd.jupyter.widget-view+json": {
        "version_major": 2,
@@ -1211,7 +1211,7 @@
      "output_type": "display_data",
      "data": {
       "text/plain": [
-       "Dropdown(description='Column 3:', index=8, options=('Optional', 'Address', 'Redirect URL', 'Status Code', 'Sta…"
+       "Dropdown(description='Column 3:', index=8, options=('Optional', 'Address', 'Redirect URL', 'Status Code', 'Sta\u2026"
       ],
       "application/vnd.jupyter.widget-view+json": {
        "version_major": 2,
@@ -1379,7 +1379,7 @@
      "output_type": "stream",
      "name": "stderr",
      "text": [
-      "Matching columns:  67%|██████▋   | 2/3 [00:00<00:00,  5.41it/s]"
+      "Matching columns:  67%|\u2588\u2588\u2588\u2588\u2588\u2588\u258b   | 2/3 [00:00<00:00,  5.41it/s]"
      ]
     },
     {
@@ -1394,7 +1394,7 @@
      "output_type": "stream",
      "name": "stderr",
      "text": [
-      "Matching columns: 100%|██████████| 3/3 [00:00<00:00,  5.64it/s]\n"
+      "Matching columns: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 3/3 [00:00<00:00,  5.64it/s]\n"
      ]
     }
    ]


### PR DESCRIPTION
## Summary
- The "Open in Colab" badge in the website migration notebook pointed to the old `portfolio/website-migration/...` path
- The repo was reorganised and `portfolio/` was removed, but this link was never updated
- Fixed to point to the current `website-migration/...` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)