### PR TITLE
Fix 16 broken Colab badge URLs across all notebooks

### DIFF
--- a/ecommerce/best-selling-products-to-xml-sitemap/best_selling_products_to_xml_sitemap.ipynb
+++ b/ecommerce/best-selling-products-to-xml-sitemap/best_selling_products_to_xml_sitemap.ipynb
@@ -25,7 +25,7 @@
     "colab_type": "text"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/best_selling_products_to_xml_sitemap/best_selling_products_to_xml_sitemap.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/ecommerce/best-selling-products-to-xml-sitemap/best_selling_products_to_xml_sitemap.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {
@@ -33,7 +33,7 @@
    "metadata": {
     "id": "R28dUAVvCrtg"
    },
-   "source": "### Script by @LeeFootSEO\n\n**Author:** Lee Foot - eCommerce SEO Consultant\n- 🌐 [Website](https://www.leefoot.com)\n- 🐦 [Twitter/X](https://x.com/LeeFootSEO)\n- 💼 [LinkedIn](https://www.linkedin.com/in/lee-foot/)\n- ✉️ [Contact](https://www.leefoot.com/contact)\n\n# Convert Best Selling Products (Transactions or Revenue) to An XML Sitemap\nWhy? Uploading an XML sitemap allows you to retrieve detailed Search Coverage data for your best performing URLs).\n\nThis means you can spot and resolve any indexing issues and make more money. (e.g. it could be that your products dominate adwords, but other issues are holding it back from organic). \n\n## How to use:\n\n1.   Download a Landing Page Report (In Excel Format) from Google Analytics (Behaviour > Site Content > Landing Pages).\n2.   Specify the domain name in the cell below\n3.   Run all cells from the Runtime menu above and upload the Analytics export when prompted.\n\n## Options:\n\n*   Specify the domain of your Website. (Required)\n*   Specify Top X Percent of Transactions / Revenue\n*   Choice of Transactions of Revenue\n\n## Output\n*   XML Sitemap - ready to upload to Search Console."
+   "source": "### Script by @LeeFootSEO\n\n**Author:** Lee Foot - eCommerce SEO Consultant\n- \ud83c\udf10 [Website](https://www.leefoot.com)\n- \ud83d\udc26 [Twitter/X](https://x.com/LeeFootSEO)\n- \ud83d\udcbc [LinkedIn](https://www.linkedin.com/in/lee-foot/)\n- \u2709\ufe0f [Contact](https://www.leefoot.com/contact)\n\n# Convert Best Selling Products (Transactions or Revenue) to An XML Sitemap\nWhy? Uploading an XML sitemap allows you to retrieve detailed Search Coverage data for your best performing URLs).\n\nThis means you can spot and resolve any indexing issues and make more money. (e.g. it could be that your products dominate adwords, but other issues are holding it back from organic). \n\n## How to use:\n\n1.   Download a Landing Page Report (In Excel Format) from Google Analytics (Behaviour > Site Content > Landing Pages).\n2.   Specify the domain name in the cell below\n3.   Run all cells from the Runtime menu above and upload the Analytics export when prompted.\n\n## Options:\n\n*   Specify the domain of your Website. (Required)\n*   Specify Top X Percent of Transactions / Revenue\n*   Choice of Transactions of Revenue\n\n## Output\n*   XML Sitemap - ready to upload to Search Console."
   },
   {
    "cell_type": "markdown",

--- a/ecommerce/internal-search-mapper/map_internal_searches_to_pages_v1_2.ipynb
+++ b/ecommerce/internal-search-mapper/map_internal_searches_to_pages_v1_2.ipynb
@@ -25,7 +25,7 @@
     "colab_type": "text"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/Map_Internal_Searches_to_Pages_v1_2.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/ecommerce/internal-search-mapper/map_internal_searches_to_pages_v1_2.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {
@@ -33,7 +33,7 @@
    "metadata": {
     "id": "vaTP7osSQvcy"
    },
-   "source": "### Script by @LeeFootSEO\n\n**Author:** Lee Foot - eCommerce SEO Consultant\n- 🌐 [Website](https://www.leefoot.com)\n- 🐦 [Twitter/X](https://x.com/LeeFootSEO)\n- 💼 [LinkedIn](https://www.linkedin.com/in/lee-foot/)\n- ✉️ [Contact](https://www.leefoot.com/contact)\n\n# Internal Search Report Mapper V2\n\nTakes the Google Analytics search terms report and merges with a Screaming Frog crawl file to find opportunities to map internal searches to.\n\n#Input Files\n\n1.   Search Terms Report - (Analytics > Behaviour > Site Search > Search Terms)\n2.   Screaming Frog Crawl - Internal_html.csv"
+   "source": "### Script by @LeeFootSEO\n\n**Author:** Lee Foot - eCommerce SEO Consultant\n- \ud83c\udf10 [Website](https://www.leefoot.com)\n- \ud83d\udc26 [Twitter/X](https://x.com/LeeFootSEO)\n- \ud83d\udcbc [LinkedIn](https://www.linkedin.com/in/lee-foot/)\n- \u2709\ufe0f [Contact](https://www.leefoot.com/contact)\n\n# Internal Search Report Mapper V2\n\nTakes the Google Analytics search terms report and merges with a Screaming Frog crawl file to find opportunities to map internal searches to.\n\n#Input Files\n\n1.   Search Terms Report - (Analytics > Behaviour > Site Search > Search Terms)\n2.   Screaming Frog Crawl - Internal_html.csv"
   },
   {
    "cell_type": "code",
@@ -59,11 +59,11 @@
       "Requirement already satisfied: seaborn>=0.11.0 in /usr/local/lib/python3.7/dist-packages (from polyfuzz) (0.11.1)\n",
       "Collecting numpy<=1.19.4,>=1.18.5\n",
       "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/a5/bb/87d668b353848b93baab0a64cddf6408c40717f099539668c3d26fe39f7e/numpy-1.19.4-cp37-cp37m-manylinux2010_x86_64.whl (14.5MB)\n",
-      "\u001b[K     |████████████████████████████████| 14.5MB 261kB/s \n",
+      "\u001b[K     |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 14.5MB 261kB/s \n",
       "\u001b[?25hRequirement already satisfied: scipy>=1.3.1 in /usr/local/lib/python3.7/dist-packages (from polyfuzz) (1.4.1)\n",
       "Collecting rapidfuzz>=0.13.1\n",
       "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/7d/b1/af677055e9d6a38c884c2ed809a820de68ec2627ad2fcb4b3b9706f97131/rapidfuzz-1.4.1-cp37-cp37m-manylinux2010_x86_64.whl (749kB)\n",
-      "\u001b[K     |████████████████████████████████| 757kB 36.8MB/s \n",
+      "\u001b[K     |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 757kB 36.8MB/s \n",
       "\u001b[?25hRequirement already satisfied: scikit-learn>=0.22.2.post1 in /usr/local/lib/python3.7/dist-packages (from polyfuzz) (0.22.2.post1)\n",
       "Requirement already satisfied: joblib>=0.14.0 in /usr/local/lib/python3.7/dist-packages (from polyfuzz) (1.0.1)\n",
       "Requirement already satisfied: tqdm>=4.41.1 in /usr/local/lib/python3.7/dist-packages (from polyfuzz) (4.41.1)\n",
@@ -513,7 +513,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>308 rows × 8 columns</p>\n",
+       "<p>308 rows \u00d7 8 columns</p>\n",
        "</div>"
       ],
       "text/plain": [

--- a/keyword-clustering/semantic-clustering/legacy-scripts/legacy-clustering-colab-sheets/Keyword_Clustering_Tool_V1.ipynb
+++ b/keyword-clustering/semantic-clustering/legacy-scripts/legacy-clustering-colab-sheets/Keyword_Clustering_Tool_V1.ipynb
@@ -25,7 +25,7 @@
     "colab_type": "text"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/Keyword_Clustering_Tool/Keyword_Clustering_Tool_V1.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/keyword-clustering/semantic-clustering/legacy-scripts/legacy-clustering-colab-sheets/Keyword_Clustering_Tool_V1.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/keyword-clustering/semantic-clustering/legacy-scripts/legacy-clustering-colab-sheets/Keyword_Clustering_Tool_V2.ipynb
+++ b/keyword-clustering/semantic-clustering/legacy-scripts/legacy-clustering-colab-sheets/Keyword_Clustering_Tool_V2.ipynb
@@ -24,7 +24,7 @@
     "colab_type": "text"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/Keyword_Clustering_Tool/Keyword_Clustering_Tool_V2.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/keyword-clustering/semantic-clustering/legacy-scripts/legacy-clustering-colab-sheets/Keyword_Clustering_Tool_V2.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {
@@ -65,13 +65,13 @@
       "Requirement already satisfied: scikit-learn>=0.22.2.post1 in /usr/local/lib/python3.7/dist-packages (from polyfuzz) (0.22.2.post1)\n",
       "Collecting numpy>=1.20.0\n",
       "  Downloading numpy-1.21.3-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (15.7 MB)\n",
-      "\u001b[K     |████████████████████████████████| 15.7 MB 58 kB/s \n",
+      "\u001b[K     |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 15.7 MB 58 kB/s \n",
       "\u001b[?25hRequirement already satisfied: joblib>=0.14.0 in /usr/local/lib/python3.7/dist-packages (from polyfuzz) (1.0.1)\n",
       "Requirement already satisfied: tqdm>=4.41.1 in /usr/local/lib/python3.7/dist-packages (from polyfuzz) (4.62.3)\n",
       "Requirement already satisfied: scipy>=1.3.1 in /usr/local/lib/python3.7/dist-packages (from polyfuzz) (1.4.1)\n",
       "Collecting rapidfuzz>=0.13.1\n",
       "  Downloading rapidfuzz-1.8.2-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl (1.6 MB)\n",
-      "\u001b[K     |████████████████████████████████| 1.6 MB 69.4 MB/s \n",
+      "\u001b[K     |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 1.6 MB 69.4 MB/s \n",
       "\u001b[?25hRequirement already satisfied: matplotlib>=3.2.2 in /usr/local/lib/python3.7/dist-packages (from polyfuzz) (3.2.2)\n",
       "Requirement already satisfied: pandas>=0.25.3 in /usr/local/lib/python3.7/dist-packages (from polyfuzz) (1.1.5)\n",
       "Requirement already satisfied: seaborn>=0.11.0 in /usr/local/lib/python3.7/dist-packages (from polyfuzz) (0.11.2)\n",

--- a/keyword-clustering/semantic-clustering/legacy-scripts/legacy-clustering-colab-sheets/Keyword_Clustering_Tool_V3.ipynb
+++ b/keyword-clustering/semantic-clustering/legacy-scripts/legacy-clustering-colab-sheets/Keyword_Clustering_Tool_V3.ipynb
@@ -24,7 +24,7 @@
     "colab_type": "text"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/Keyword_Clustering_Tool/Keyword_Clustering_Tool_V3.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/keyword-clustering/semantic-clustering/legacy-scripts/legacy-clustering-colab-sheets/Keyword_Clustering_Tool_V3.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {
@@ -421,7 +421,7 @@
     "spec_chars = [\"!\",'\"',\"#\",\"%\",\"'\",\"(\",\")\",\n",
     "              \"*\",\"+\",\",\",\"-\",\".\",\"/\",\":\",\";\",\"<\",\n",
     "              \"=\",\">\",\"?\",\"@\",\"[\",\"\\\\\",\"]\",\"^\",\"_\",\n",
-    "              \"`\",\"{\",\"|\",\"}\",\"~\",\"–\"]\n",
+    "              \"`\",\"{\",\"|\",\"}\",\"~\",\"\u2013\"]\n",
     "for char in spec_chars:\n",
     "    df_1['Keyword'] = df_1['Keyword'].str.replace(char, ' ')"
    ],
@@ -475,7 +475,7 @@
      "output_type": "stream",
      "name": "stderr",
      "text": [
-      "100%|██████████| 4981/4981 [00:01<00:00, 2683.57it/s]\n"
+      "100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 4981/4981 [00:01<00:00, 2683.57it/s]\n"
      ]
     }
    ]

--- a/keyword-clustering/semantic-clustering/legacy-scripts/legacy-clustering-colab-sheets/keyword_clustering_tool.ipynb
+++ b/keyword-clustering/semantic-clustering/legacy-scripts/legacy-clustering-colab-sheets/keyword_clustering_tool.ipynb
@@ -24,7 +24,7 @@
     "colab_type": "text"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/keyword_clustering_tool/keyword_clustering_tool.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/keyword-clustering/semantic-clustering/legacy-scripts/legacy-clustering-colab-sheets/keyword_clustering_tool.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/keyword-clustering/semantic-clustering/legacy-scripts/semantic-clustering-tool-sej/SEJ_Semantic_Clustering_Tool_by_LeeFootSEO.ipynb
+++ b/keyword-clustering/semantic-clustering/legacy-scripts/semantic-clustering-tool-sej/SEJ_Semantic_Clustering_Tool_by_LeeFootSEO.ipynb
@@ -27,7 +27,7 @@
     "colab_type": "text"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/search_engine_journal/SEJ_Semantic_Clustering_Tool_by_LeeFootSEO.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/keyword-clustering/semantic-clustering/legacy-scripts/semantic-clustering-tool-sej/SEJ_Semantic_Clustering_Tool_by_LeeFootSEO.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/keyword-research/bulk-keyword-tagger/bulk_keyword_tagger_v2.ipynb
+++ b/keyword-research/bulk-keyword-tagger/bulk_keyword_tagger_v2.ipynb
@@ -24,12 +24,12 @@
     "colab_type": "text"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/bulk_keyword_tagger/bulk_keyword_tagger_v2.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/keyword-research/bulk-keyword-tagger/bulk_keyword_tagger_v2.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {
    "cell_type": "markdown",
-   "source": "### Script by @LeeFootSEO\n\n**Author:** Lee Foot - eCommerce SEO Consultant\n- 🌐 [Website](https://www.leefoot.com)\n- 🐦 [Twitter/X](https://x.com/LeeFootSEO)\n- 💼 [LinkedIn](https://www.linkedin.com/in/lee-foot/)\n- ✉️ [Contact](https://www.leefoot.com/contact)\n\n**Instructions**\n\n1.   Run all cells (Runtime > Run All or Control + F9)\n2.   Upload a list of Keywords in CSV format when prompted [Sample Data Here](https://docs.google.com/spreadsheets/d/12NTaafyf22RwIIzXYnKp6FGFEmfGxysuNuT3asZn8F4/edit#gid=0)\n3.   Upload a list of negative keywords to tag with. [Sample Data Here](https://docs.google.com/spreadsheets/d/15kf8b7JzP_3Chv-nVX5IW6z9OWdQzTbET3lZtDH0fdk/edit#gid=0)",
+   "source": "### Script by @LeeFootSEO\n\n**Author:** Lee Foot - eCommerce SEO Consultant\n- \ud83c\udf10 [Website](https://www.leefoot.com)\n- \ud83d\udc26 [Twitter/X](https://x.com/LeeFootSEO)\n- \ud83d\udcbc [LinkedIn](https://www.linkedin.com/in/lee-foot/)\n- \u2709\ufe0f [Contact](https://www.leefoot.com/contact)\n\n**Instructions**\n\n1.   Run all cells (Runtime > Run All or Control + F9)\n2.   Upload a list of Keywords in CSV format when prompted [Sample Data Here](https://docs.google.com/spreadsheets/d/12NTaafyf22RwIIzXYnKp6FGFEmfGxysuNuT3asZn8F4/edit#gid=0)\n3.   Upload a list of negative keywords to tag with. [Sample Data Here](https://docs.google.com/spreadsheets/d/15kf8b7JzP_3Chv-nVX5IW6z9OWdQzTbET3lZtDH0fdk/edit#gid=0)",
    "metadata": {
     "id": "zL1Gw_7wDvM1"
    }

--- a/linking/map-urls-wayback-machine/google-colab/map-links-from-wayback-machine/archive_org_redirect_mapper.ipynb
+++ b/linking/map-urls-wayback-machine/google-colab/map-links-from-wayback-machine/archive_org_redirect_mapper.ipynb
@@ -25,7 +25,7 @@
     "colab_type": "text"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/archive.org_broken_link_automapper/archive_org_redirect_mapper.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/linking/map-urls-wayback-machine/google-colab/map-links-from-wayback-machine/archive_org_redirect_mapper.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {
@@ -33,7 +33,7 @@
    "metadata": {
     "id": "l7pb60AQVvBx"
    },
-   "source": "### Script by @LeeFootSEO\n\n**Author:** Lee Foot - eCommerce SEO Consultant\n- 🌐 [Website](https://www.leefoot.com)\n- 🐦 [Twitter/X](https://x.com/LeeFootSEO)\n- 💼 [LinkedIn](https://www.linkedin.com/in/lee-foot/)\n- ✉️ [Contact](https://www.leefoot.com/contact)\n\n# Visualise Search Console Coverage Reports\nSpot issues fast by visualising your Search Console Coverage Reports. Especially useful to visualise low quality folder paths at a glance (crawled, not indexed).\n\n## How to use:\nRun all cells and upload a Search Console Coverage Report in *Excel* format. \n\n### Options:\nOption to set a starting folder depth (Useful to step through cctld folders)\n\n### Output\nExports a Treemap and Sunburst Chart from the coverage report\n\n*   Interactive Treemap .html file\n*   Interactive Sunburst .html file"
+   "source": "### Script by @LeeFootSEO\n\n**Author:** Lee Foot - eCommerce SEO Consultant\n- \ud83c\udf10 [Website](https://www.leefoot.com)\n- \ud83d\udc26 [Twitter/X](https://x.com/LeeFootSEO)\n- \ud83d\udcbc [LinkedIn](https://www.linkedin.com/in/lee-foot/)\n- \u2709\ufe0f [Contact](https://www.leefoot.com/contact)\n\n# Visualise Search Console Coverage Reports\nSpot issues fast by visualising your Search Console Coverage Reports. Especially useful to visualise low quality folder paths at a glance (crawled, not indexed).\n\n## How to use:\nRun all cells and upload a Search Console Coverage Report in *Excel* format. \n\n### Options:\nOption to set a starting folder depth (Useful to step through cctld folders)\n\n### Output\nExports a Treemap and Sunburst Chart from the coverage report\n\n*   Interactive Treemap .html file\n*   Interactive Sunburst .html file"
   },
   {
    "cell_type": "code",

--- a/reporting/create-bcg-matrix-from-ga-landing-page-report/create_bcg_matrix_from_ga_landing_page_report.ipynb
+++ b/reporting/create-bcg-matrix-from-ga-landing-page-report/create_bcg_matrix_from_ga_landing_page_report.ipynb
@@ -25,7 +25,7 @@
     "colab_type": "text"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/create_bcg_matrix_from_ga_landing_page_report/create_bcg_matrix_from_ga_landing_page_report.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/reporting/create-bcg-matrix-from-ga-landing-page-report/create_bcg_matrix_from_ga_landing_page_report.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {
@@ -33,7 +33,7 @@
    "metadata": {
     "id": "m82FSMw_vYoM"
    },
-   "source": "### Script by @LeeFootSEO\n\n**Author:** Lee Foot - eCommerce SEO Consultant\n- 🌐 [Website](https://www.leefoot.com)\n- 🐦 [Twitter/X](https://x.com/LeeFootSEO)\n- 💼 [LinkedIn](https://www.linkedin.com/in/lee-foot/)\n- ✉️ [Contact](https://www.leefoot.com/contact)\n\n# Four Quadrant Matrix Creator\n\n**How to Use: **\n\n1.   Upload a GA Landing Page Report with Sessions & Revenue. \n2.   Lookup for a Chrome Popup asking to download multiple files at once.\n3.   Done!\n\nThis script takes a landing page report and creates a BCG matric from the data. This is useful for spotting any outliers in the data. (For example, high revenue but low traffic? Strategise to increase the traffic - maybe run a paid campaign and so on).\n\nThe Output:\nThis script output a top level report from a custom starting URL depth, and then loops one level deeper. (e.g. it'll report on the parent category data and then loop through for each subcategory and generate an independant report for each)."
+   "source": "### Script by @LeeFootSEO\n\n**Author:** Lee Foot - eCommerce SEO Consultant\n- \ud83c\udf10 [Website](https://www.leefoot.com)\n- \ud83d\udc26 [Twitter/X](https://x.com/LeeFootSEO)\n- \ud83d\udcbc [LinkedIn](https://www.linkedin.com/in/lee-foot/)\n- \u2709\ufe0f [Contact](https://www.leefoot.com/contact)\n\n# Four Quadrant Matrix Creator\n\n**How to Use: **\n\n1.   Upload a GA Landing Page Report with Sessions & Revenue. \n2.   Lookup for a Chrome Popup asking to download multiple files at once.\n3.   Done!\n\nThis script takes a landing page report and creates a BCG matric from the data. This is useful for spotting any outliers in the data. (For example, high revenue but low traffic? Strategise to increase the traffic - maybe run a paid campaign and so on).\n\nThe Output:\nThis script output a top level report from a custom starting URL depth, and then loops one level deeper. (e.g. it'll report on the parent category data and then loop through for each subcategory and generate an independant report for each)."
   },
   {
    "cell_type": "code",

--- a/reporting/top-traffic-pages-search-console-sej/Top_Traffic_Pages_Search_Console_API_V1.ipynb
+++ b/reporting/top-traffic-pages-search-console-sej/Top_Traffic_Pages_Search_Console_API_V1.ipynb
@@ -7,7 +7,7 @@
     "colab_type": "text"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/search_engine_journal/Top_Traffic_Pages_Search_Console_API_V1.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/reporting/top-traffic-pages-search-console-sej/Top_Traffic_Pages_Search_Console_API_V1.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/reporting/visualise-links-screaming_frog/visualise_links_screaming_frog.ipynb
+++ b/reporting/visualise-links-screaming_frog/visualise_links_screaming_frog.ipynb
@@ -25,7 +25,7 @@
     "colab_type": "text"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/visualise_links_screaming_frog/visualise_links_screaming_frog.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/reporting/visualise-links-screaming_frog/visualise_links_screaming_frog.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {
@@ -33,7 +33,7 @@
    "metadata": {
     "id": "9zI6__uY6j2h"
    },
-   "source": "### Script by @LeeFootSEO\n\n**Author:** Lee Foot - eCommerce SEO Consultant\n- 🌐 [Website](https://www.leefoot.com)\n- 🐦 [Twitter/X](https://x.com/LeeFootSEO)\n- 💼 [LinkedIn](https://www.linkedin.com/in/lee-foot/)\n- ✉️ [Contact](https://www.leefoot.com/contact)\n\n# Visualise Internal Linking Structure with Treemaps\n\n## File Formats (CSV Exports Only!)\n*   Screaming Frog Crawl Export\n*   ahrefs.com Backlinks Report\n*   Search Console Internal Links Report\n*   Search Console External Links Report\n\n# How to use:\nRun all cells and upload a csv export from either screaming frog, ahrefs, or search console to visualise internal or external links to different section of your Website."
+   "source": "### Script by @LeeFootSEO\n\n**Author:** Lee Foot - eCommerce SEO Consultant\n- \ud83c\udf10 [Website](https://www.leefoot.com)\n- \ud83d\udc26 [Twitter/X](https://x.com/LeeFootSEO)\n- \ud83d\udcbc [LinkedIn](https://www.linkedin.com/in/lee-foot/)\n- \u2709\ufe0f [Contact](https://www.leefoot.com/contact)\n\n# Visualise Internal Linking Structure with Treemaps\n\n## File Formats (CSV Exports Only!)\n*   Screaming Frog Crawl Export\n*   ahrefs.com Backlinks Report\n*   Search Console Internal Links Report\n*   Search Console External Links Report\n\n# How to use:\nRun all cells and upload a csv export from either screaming frog, ahrefs, or search console to visualise internal or external links to different section of your Website."
   },
   {
    "cell_type": "code",

--- a/reporting/visualise-search-console-coverage-reports/visualise_search_console_coverage_reports.ipynb
+++ b/reporting/visualise-search-console-coverage-reports/visualise_search_console_coverage_reports.ipynb
@@ -25,7 +25,7 @@
     "colab_type": "text"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/visualise_search_console_coverage_reports/visualise_search_console_coverage_reports.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/reporting/visualise-search-console-coverage-reports/visualise_search_console_coverage_reports.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {
@@ -33,7 +33,7 @@
    "metadata": {
     "id": "l7pb60AQVvBx"
    },
-   "source": "### Script by @LeeFootSEO\n\n**Author:** Lee Foot - eCommerce SEO Consultant\n- 🌐 [Website](https://www.leefoot.com)\n- 🐦 [Twitter/X](https://x.com/LeeFootSEO)\n- 💼 [LinkedIn](https://www.linkedin.com/in/lee-foot/)\n- ✉️ [Contact](https://www.leefoot.com/contact)\n\n# Visualise Search Console Coverage Reports\nSpot issues fast by visualising your Search Console Coverage Reports. Especially useful to visualise low quality folder paths at a glance (crawled, not indexed).\n\n## How to use:\nRun all cells and upload a Search Console Coverage Report in *Excel* format. \n\n### Options:\nOption to set a starting folder depth (Useful to step through cctld folders)\n\n### Output\nExports a Treemap and Sunburst Chart from the coverage report\n\n*   Interactive Treemap .html file\n*   Interactive Sunburst .html file"
+   "source": "### Script by @LeeFootSEO\n\n**Author:** Lee Foot - eCommerce SEO Consultant\n- \ud83c\udf10 [Website](https://www.leefoot.com)\n- \ud83d\udc26 [Twitter/X](https://x.com/LeeFootSEO)\n- \ud83d\udcbc [LinkedIn](https://www.linkedin.com/in/lee-foot/)\n- \u2709\ufe0f [Contact](https://www.leefoot.com/contact)\n\n# Visualise Search Console Coverage Reports\nSpot issues fast by visualising your Search Console Coverage Reports. Especially useful to visualise low quality folder paths at a glance (crawled, not indexed).\n\n## How to use:\nRun all cells and upload a Search Console Coverage Report in *Excel* format. \n\n### Options:\nOption to set a starting folder depth (Useful to step through cctld folders)\n\n### Output\nExports a Treemap and Sunburst Chart from the coverage report\n\n*   Interactive Treemap .html file\n*   Interactive Sunburst .html file"
   },
   {
    "cell_type": "code",

--- a/search-engine-journal/SEJ_Semantic_Clustering_Tool_by_LeeFootSEO.ipynb
+++ b/search-engine-journal/SEJ_Semantic_Clustering_Tool_by_LeeFootSEO.ipynb
@@ -27,7 +27,7 @@
     "colab_type": "text"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/search_engine_journal/SEJ_Semantic_Clustering_Tool_by_LeeFootSEO.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/search-engine-journal/SEJ_Semantic_Clustering_Tool_by_LeeFootSEO.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/search-engine-journal/Top_Traffic_Pages_Search_Console_API_V1.ipynb
+++ b/search-engine-journal/Top_Traffic_Pages_Search_Console_API_V1.ipynb
@@ -7,7 +7,7 @@
     "colab_type": "text"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/search_engine_journal/Top_Traffic_Pages_Search_Console_API_V1.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/search-engine-journal/Top_Traffic_Pages_Search_Console_API_V1.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {

--- a/site-search/map-site-searches-to-landing-pages/automatically_map_internal_searches_to_landing_pages.ipynb
+++ b/site-search/map-site-searches-to-landing-pages/automatically_map_internal_searches_to_landing_pages.ipynb
@@ -25,7 +25,7 @@
     "colab_type": "text"
    },
    "source": [
-    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/automatically_map_internal_searches_to_landing_pages/automatically_map_internal_searches_to_landing_pages.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+    "<a href=\"https://colab.research.google.com/github/searchsolved/search-solved-public-seo/blob/main/site-search/map-site-searches-to-landing-pages/automatically_map_internal_searches_to_landing_pages.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
    ]
   },
   {
@@ -33,7 +33,7 @@
    "metadata": {
     "id": "vaTP7osSQvcy"
    },
-   "source": "### Script by @LeeFootSEO\n\n**Author:** Lee Foot - eCommerce SEO Consultant\n- 🌐 [Website](https://www.leefoot.com)\n- 🐦 [Twitter/X](https://x.com/LeeFootSEO)\n- 💼 [LinkedIn](https://www.linkedin.com/in/lee-foot/)\n- ✉️ [Contact](https://www.leefoot.com/contact)\n\n#Internal Search Report Mapper V2\n\nWhat This Script Does\n\nTakes the Google Analytics search terms report and merges with a Screaming Frog crawl file to find opportunities to map internal searches to.\n\n#Input Files\n\n1.   Search Terms Report - (Analytics > Behaviour > Site Search > Search Terms)\n2.   Screaming Frog Crawl - Internal_html.csv"
+   "source": "### Script by @LeeFootSEO\n\n**Author:** Lee Foot - eCommerce SEO Consultant\n- \ud83c\udf10 [Website](https://www.leefoot.com)\n- \ud83d\udc26 [Twitter/X](https://x.com/LeeFootSEO)\n- \ud83d\udcbc [LinkedIn](https://www.linkedin.com/in/lee-foot/)\n- \u2709\ufe0f [Contact](https://www.leefoot.com/contact)\n\n#Internal Search Report Mapper V2\n\nWhat This Script Does\n\nTakes the Google Analytics search terms report and merges with a Screaming Frog crawl file to find opportunities to map internal searches to.\n\n#Input Files\n\n1.   Search Terms Report - (Analytics > Behaviour > Site Search > Search Terms)\n2.   Screaming Frog Crawl - Internal_html.csv"
   },
   {
    "cell_type": "code",
@@ -59,11 +59,11 @@
       "Requirement already satisfied: seaborn>=0.11.0 in /usr/local/lib/python3.7/dist-packages (from polyfuzz) (0.11.1)\n",
       "Collecting numpy<=1.19.4,>=1.18.5\n",
       "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/a5/bb/87d668b353848b93baab0a64cddf6408c40717f099539668c3d26fe39f7e/numpy-1.19.4-cp37-cp37m-manylinux2010_x86_64.whl (14.5MB)\n",
-      "\u001b[K     |████████████████████████████████| 14.5MB 261kB/s \n",
+      "\u001b[K     |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 14.5MB 261kB/s \n",
       "\u001b[?25hRequirement already satisfied: scipy>=1.3.1 in /usr/local/lib/python3.7/dist-packages (from polyfuzz) (1.4.1)\n",
       "Collecting rapidfuzz>=0.13.1\n",
       "\u001b[?25l  Downloading https://files.pythonhosted.org/packages/7d/b1/af677055e9d6a38c884c2ed809a820de68ec2627ad2fcb4b3b9706f97131/rapidfuzz-1.4.1-cp37-cp37m-manylinux2010_x86_64.whl (749kB)\n",
-      "\u001b[K     |████████████████████████████████| 757kB 36.8MB/s \n",
+      "\u001b[K     |\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 757kB 36.8MB/s \n",
       "\u001b[?25hRequirement already satisfied: scikit-learn>=0.22.2.post1 in /usr/local/lib/python3.7/dist-packages (from polyfuzz) (0.22.2.post1)\n",
       "Requirement already satisfied: joblib>=0.14.0 in /usr/local/lib/python3.7/dist-packages (from polyfuzz) (1.0.1)\n",
       "Requirement already satisfied: tqdm>=4.41.1 in /usr/local/lib/python3.7/dist-packages (from polyfuzz) (4.41.1)\n",
@@ -513,7 +513,7 @@
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>308 rows × 8 columns</p>\n",
+       "<p>308 rows \u00d7 8 columns</p>\n",
        "</div>"
       ],
       "text/plain": [


### PR DESCRIPTION
## Summary
- All 16 notebooks in the repo had stale "Open in Colab" badge URLs pointing to pre-reorganisation paths
- Updated each to point to the current file location in the repo

### Affected notebooks
- ecommerce (2): best-selling-products-to-xml-sitemap, internal-search-mapper
- keyword-clustering (5): 4 legacy clustering tools + SEJ clustering tool
- keyword-research (1): bulk-keyword-tagger
- linking (1): wayback-machine mapper
- reporting (4): BCG matrix, top traffic pages, visualise links, visualise coverage
- search-engine-journal (2): SEJ clustering, top traffic pages
- site-search (1): map-site-searches-to-landing-pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)